### PR TITLE
Fixed to work with PureScript 0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,14 +14,14 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.0.0",
-    "purescript-arrays": "^4.0.1",
-    "purescript-globals": "^3.0.0",
-    "purescript-tuples": "^4.0.0"
+    "purescript-prelude": "^4.1.0",
+    "purescript-arrays": "^5.0.0",
+    "purescript-globals": "^4.0.0",
+    "purescript-tuples": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-assert": "^3.0.0",
-    "purescript-console": "^3.0.0",
-    "purescript-psci-support": "^3.0.0"
+    "purescript-assert": "^4.0.0",
+    "purescript-console": "^4.1.0",
+    "purescript-psci-support": "^4.0.0"
   }
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,17 +1,14 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE)
-
-import Test.Assert (ASSERT)
+import Effect (Effect)
 
 import Test.LinearAlgebra.Matrix (testMatrix)
 import Test.LinearAlgebra.Vector (testVector)
 import Test.PerfTest (perfTests)
 
 
-main :: ∀ eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+main :: Effect Unit
 main = do
   testMatrix
   testVector

--- a/test/Test/LinearAlgebra/Matrix.purs
+++ b/test/Test/LinearAlgebra/Matrix.purs
@@ -1,15 +1,15 @@
 module Test.LinearAlgebra.Matrix (testMatrix) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (log, CONSOLE)
+import Effect (Effect)
+import Effect.Class.Console (log)
 import Data.Maybe (Maybe(..), fromMaybe, isJust, isNothing)
-import Test.Assert (assert, ASSERT)
+import Test.Assert (assert)
 
 import LinearAlgebra.Matrix as M
 
 
-testMatrix :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testMatrix :: Effect Unit
 testMatrix = do
     log "\n# Test Matrix"
     testCreate
@@ -28,7 +28,7 @@ testMatrix = do
     testIdentity
 
 
-testCreate :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testCreate :: Effect Unit
 testCreate = do
     log " * Create matrix"
     let z1 = M.zeros 5 4
@@ -36,49 +36,49 @@ testCreate = do
     assert $ M.ncols z1 == 4
 
 
-testFromArray :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testFromArray :: Effect Unit
 testFromArray = do
     log " * From Array"
     assert $ isNothing (M.fromArray 2 3 [1.0])
     assert $ isJust (M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
 
 
-testGetRow :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testGetRow :: Effect Unit
 testGetRow = do
     log " * Get specific row"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     assert $ M.row 0 mat == [1.0, 2.0, 3.0]    
 
 
-testGetCol :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testGetCol :: Effect Unit
 testGetCol = do
     log " * Get specific column"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     assert $ M.column 1 mat == [2.0, 5.0]
 
 
-testGetValue :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testGetValue :: Effect Unit
 testGetValue = do
     log " * Get specific value"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     assert $ M.element 1 2 mat == Just 6.0
 
 
-testRows :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testRows :: Effect Unit
 testRows = do
     log " * Get list of rows"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     assert $ M.rows mat == [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
     
 
-testColumns :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testColumns :: Effect Unit
 testColumns = do
     log " * Get list of columns"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     assert $ M.columns mat == [[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]]
     
 
-testSliceColumns :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testSliceColumns :: Effect Unit
 testSliceColumns = do
     log " * Slice columns"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
@@ -86,7 +86,7 @@ testSliceColumns = do
     assert $ M.sliceCols 0 1 mat == expected
     
 
-testSliceRows :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testSliceRows :: Effect Unit
 testSliceRows = do
     log " * Slice rows"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 3 2 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
@@ -94,7 +94,7 @@ testSliceRows = do
     assert $ M.sliceRows 0 1 mat == expected
     
 
-testInsertColumn :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testInsertColumn :: Effect Unit
 testInsertColumn = do
     log " * Insert column"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 2 2 [1.0, 2.0, 4.0, 5.0]
@@ -104,7 +104,7 @@ testInsertColumn = do
     assert $ M.insertCol 0 [3.0, 6.0] mat == expected2
 
 
-testAdd :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testAdd :: Effect Unit
 testAdd = do
     log " * Multiply matrices"
     let m1 = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
@@ -112,7 +112,7 @@ testAdd = do
     assert $ M.add m1 m1 == expected
 
 
-testMultiply :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testMultiply :: Effect Unit
 testMultiply = do
     log " * Multiply matrices"
     let m1 = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
@@ -121,7 +121,7 @@ testMultiply = do
     assert $ M.multiply m1 m2 == expected
 
 
-testTranspose :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testTranspose :: Effect Unit
 testTranspose = do
     log " * Transpose matrix"
     let mat = fromMaybe (M.zeros 1 1) $ M.fromArray 2 3 [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
@@ -129,7 +129,7 @@ testTranspose = do
     assert $ M.transpose mat == expected
 
 
-testIdentity :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testIdentity :: Effect Unit
 testIdentity = do
     log " * Identity matrix"
     let expected = fromMaybe (M.zeros 1 1) $ M.fromArray 3 3 [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]

--- a/test/Test/LinearAlgebra/Vector.purs
+++ b/test/Test/LinearAlgebra/Vector.purs
@@ -1,15 +1,15 @@
 module Test.LinearAlgebra.Vector (testVector) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (log, CONSOLE)
+import Effect (Effect)
+import Effect.Class.Console (log)
 import Data.Maybe (Maybe(..))
-import Test.Assert (assert, ASSERT)
+import Test.Assert (assert)
 
 import LinearAlgebra.Vector as V
 
 
-testVector :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testVector :: Effect Unit
 testVector = do
     log "\n# Vector tests"
     testAdd
@@ -20,39 +20,39 @@ testVector = do
     testtestArgMin
 
 
-testAdd :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testAdd :: Effect Unit
 testAdd = do
     log " * Add vectors"
     assert $ V.add [1.0, 2.0, -3.0] [1.0, 1.0, 1.0, 5.0] == []
     assert $ V.add [1.0, 2.0, -3.0] [1.0, 1.0, 1.0] == [2.0, 3.0, -2.0]
 
 
-testDifference :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testDifference :: Effect Unit
 testDifference = do
     log " * Difference"
     assert $ V.diff [1.0, 2.0, -3.0] [1.0, 1.0, 1.0, 5.0] == []
     assert $ V.diff [1.0, 2.0, -3.0] [1.0, 1.0, 1.0] == [0.0, 1.0, -4.0]
 
 
-testDot :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testDot :: Effect Unit
 testDot = do
     log " * Dot product"
     assert $ V.dot [1.0, 2.0, -3.0] [1.0, 2.0, 1.0] == Just 2.0
 
 
-testMulScalar :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testMulScalar :: Effect Unit
 testMulScalar = do
     log " * Multiply by scalar"
     assert $ V.mulScalar 2.0 [1.0, 2.0, -3.0] ==  [2.0, 4.0, -6.0]
 
 
-testArgMax :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testArgMax :: Effect Unit
 testArgMax = do
     log " * argmax"
     assert $ V.argmax [1.0, 2.0, -3.0, 1.0, 2.0, 1.0] == 1
 
 
-testtestArgMin :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testtestArgMin :: Effect Unit
 testtestArgMin = do
     log " * argmin"
     assert $ V.argmin [1.0, 2.0, -3.0, 1.0, 2.0, 1.0] == 2

--- a/test/Test/PerfTest.purs
+++ b/test/Test/PerfTest.purs
@@ -1,16 +1,16 @@
 module Test.PerfTest (perfTests) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (log, CONSOLE)
+import Effect (Effect)
+import Effect.Class.Console (log)
 import Data.Array as A
 import Data.Maybe (fromJust)
-import Test.Assert (assert, ASSERT)
+import Test.Assert (assert)
 import Partial.Unsafe (unsafePartial)
 import LinearAlgebra.Matrix as M
 
 
-perfTests :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+perfTests :: Effect Unit
 perfTests = do
 
     log "\n# Run Benchmarks"


### PR DESCRIPTION
There seemed to be a few small breaking changes with PureScript 0.12.

I noticed in my application that used `purescript-linear-algebra` it wouldn't compile with the latest version of PureScript.

This is a fix to allow it to work with 0.12.